### PR TITLE
Native ESM via published .mjs

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,4 +1,4 @@
-module.exports = {
+const config = {
   plugins: [
     "@babel/transform-runtime",
     ["@babel/proposal-decorators", {
@@ -6,9 +6,10 @@ module.exports = {
     }],
     "@babel/proposal-class-properties",
     "@babel/transform-async-to-generator",
-    "@babel/proposal-async-generator-functions",
-    ["@babel/transform-modules-commonjs", {
-      mjsStrictNamespace: false
-    }]
+    "@babel/proposal-async-generator-functions"
   ]
 }
+
+if (!process.env.BABEL_ESM) config.plugins.push("@babel/transform-modules-commonjs")
+
+module.exports = config

--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,7 @@ root = true
 end_of_line = lf
 insert_final_newline = true
 
-[*.{js,json,md,yml,gitignore,npmignore,lintstagedrc,babelrc}]
+[*.{mjs,js,json,md,yml,gitignore,npmignore,lintstagedrc,babelrc}]
 charset = utf-8
 indent_style = space
 indent_size = 2

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,7 @@
   "settings": {
     "import/resolver": {
       "node": {
-        "extensions": [".js", ".mjs"]
+        "extensions": [".mjs", ".js"]
       }
     }
   },

--- a/.huskyrc.json
+++ b/.huskyrc.json
@@ -1,6 +1,6 @@
 {
   "hooks": {
-    "pre-commit": "yarn staged",
-    "pre-push": "yarn report"
+    "pre-commit": "npm run staged",
+    "pre-push": "npm run report"
   }
 }

--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,3 +1,3 @@
 {
-  "src/**/*.js": "node_modules/.bin/eslint --fix"
+  "src/**/*.js": "eslint --fix"
 }

--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,3 +1,3 @@
 {
-  "src/**/*.js": "eslint --fix"
+  "src/**/*.mjs": "eslint --fix"
 }

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+scripts-prepend-node-path=true

--- a/package.json
+++ b/package.json
@@ -18,18 +18,18 @@
   "scripts": {
     "lint": "eslint src",
     "staged": "lint-staged",
-    "make": "npm run make:mjs && npm run make:js",
-    "make:mjs": "BABEL_ESM=1 babel src -d . --keep-file-extension",
-    "make:js": "babel src -d .",
+    "prepare": "npm run prepare:mjs && npm run prepare:js",
+    "prepare:mjs": "BABEL_ESM=1 babel src -d . --keep-file-extension",
+    "prepare:js": "babel src -d .",
     "watch": "babel src -w -d .",
     "make:ci": "babel src -s -d .",
-    "m": "npm run make",
+    "p": "npm run prepare",
     "w": "npm run watch",
     "cleanup": "rimraf lib test",
     "test": "ava",
-    "coverage": "npm run cleanup && npm run make:ci && nyc npm test && npm run cleanup && npm run make",
-    "report": "npm run cleanup && npm run make:ci && nyc npm test && nyc report --reporter=html npm test && npm run cleanup && npm run make",
-    "ci": "npm run make:ci && nyc npm test && nyc report --reporter=lcov npm test && codecov && npm run cleanup && npm run make"
+    "coverage": "npm run cleanup && npm run make:ci && nyc npm test && npm run cleanup && npm run prepare",
+    "report": "npm run cleanup && npm run make:ci && nyc npm test && nyc report --reporter=html npm test && npm run cleanup && npm run prepare",
+    "ci": "npm run make:ci && nyc npm test && nyc report --reporter=lcov npm test && codecov && npm run cleanup && npm run prepare"
   },
   "ava": {
     "files": [

--- a/package.json
+++ b/package.json
@@ -16,18 +16,18 @@
     "node": ">= 8"
   },
   "scripts": {
-    "lint": "node_modules/.bin/eslint src",
-    "staged": "node_modules/.bin/lint-staged",
-    "make": "node_modules/.bin/babel src -d .",
-    "watch": "node_modules/.bin/babel src -w -d .",
-    "make:ci": "node_modules/.bin/babel src -s -d .",
-    "m": "yarn make",
-    "w": "yarn watch",
-    "cleanup": "node_modules/.bin/rimraf lib test",
-    "test": "node_modules/.bin/ava",
-    "coverage": "yarn cleanup && yarn make:ci && node_modules/.bin/nyc yarn test && yarn cleanup && yarn make",
-    "report": "yarn cleanup && yarn make:ci && node_modules/.bin/nyc yarn test && node_modules/.bin/nyc report --reporter=html yarn test && yarn cleanup && yarn make",
-    "ci": "yarn make:ci && node_modules/.bin/nyc yarn test && node_modules/.bin/nyc report --reporter=lcov yarn test && node_modules/.bin/codecov && yarn cleanup && yarn make"
+    "lint": "eslint src",
+    "staged": "lint-staged",
+    "make": "babel src -d .",
+    "watch": "babel src -w -d .",
+    "make:ci": "babel src -s -d .",
+    "m": "npm run make",
+    "w": "npm run watch",
+    "cleanup": "rimraf lib test",
+    "test": "ava",
+    "coverage": "npm run cleanup && npm run make:ci && nyc npm test && npm run cleanup && npm run make",
+    "report": "npm run cleanup && npm run make:ci && nyc npm test && nyc report --reporter=html npm test && npm run cleanup && npm run make",
+    "ci": "npm run make:ci && nyc npm test && nyc report --reporter=lcov npm test && codecov && npm run cleanup && npm run make"
   },
   "ava": {
     "files": [

--- a/package.json
+++ b/package.json
@@ -11,14 +11,16 @@
   ],
   "author": "Nick K. <nick.kruchinin@gmail.com>",
   "license": "MIT",
-  "main": "lib/FormData.js",
+  "main": "lib/FormData",
   "engines": {
     "node": ">= 8"
   },
   "scripts": {
     "lint": "eslint src",
     "staged": "lint-staged",
-    "make": "babel src -d .",
+    "make": "npm run make:mjs && npm run make:js",
+    "make:mjs": "BABEL_ESM=1 babel src -d . --keep-file-extension",
+    "make:js": "babel src -d .",
     "watch": "babel src -w -d .",
     "make:ci": "babel src -s -d .",
     "m": "npm run make",

--- a/src/lib/FormData.mjs
+++ b/src/lib/FormData.mjs
@@ -1,5 +1,5 @@
-import {Readable} from "stream"
-import {basename} from "path"
+import stream from "stream"
+import path from "path"
 
 import invariant from "@octetstream/invariant"
 import mimes from "mime-types"
@@ -66,7 +66,7 @@ class FormData {
 
     const read = this.__read
 
-    this.__stream = new Readable({read})
+    this.__stream = new stream.Readable({read})
 
     if (isArray(fields)) {
       this.__appendFromInitialFields(fields)
@@ -218,12 +218,12 @@ class FormData {
 
     // Getting a filename for Buffer and Readable values
     if (isBuffer(value) && filename) {
-      filename = basename(filename)
+      filename = path.basename(filename)
     } else if (isReadable(value) && (value.path || filename)) {
       // Readable stream which created from fs.createReadStream
       // have a "path" property. So, we can get a "filename"
       // from the stream itself.
-      filename = basename(value.path || filename)
+      filename = path.basename(value.path || filename)
     } else {
       // The regular values shouldn't have "filename" property
       filename = undefined

--- a/src/lib/util/isBuffer.mjs
+++ b/src/lib/util/isBuffer.mjs
@@ -1,3 +1,3 @@
 const isBuffer = val => val instanceof Buffer
 
-module.exports = isBuffer
+export default isBuffer

--- a/src/lib/util/isReadable.mjs
+++ b/src/lib/util/isReadable.mjs
@@ -1,5 +1,5 @@
-const {Readable} = require("stream")
+import stream from "stream"
 
-const isReadable = val => val instanceof Readable
+const isReadable = val => val instanceof stream.Readable
 
-module.exports = isReadable
+export default isReadable

--- a/src/test/FormData/common.mjs
+++ b/src/test/FormData/common.mjs
@@ -5,7 +5,7 @@ import test from "ava"
 import pq from "proxyquire"
 import req from "supertest"
 
-import {spy} from "sinon"
+import sinon from "sinon"
 import {createReadStream, readFile} from "promise-fs"
 
 import boundary from "../../lib/util/boundary"
@@ -26,7 +26,7 @@ test("The stream accessor should return Readable stream", t => {
 test("Boundary accessor should return a correct value", t => {
   t.plan(1)
 
-  const spyondary = spy(boundary)
+  const spyondary = sinon.spy(boundary)
 
   const MockedFD = pq("../../lib/FormData", {
     "./util/boundary": {
@@ -44,7 +44,7 @@ test("Boundary accessor should return a correct value", t => {
 test("Should return a correct headers", t => {
   t.plan(1)
 
-  const spyondary = spy(boundary)
+  const spyondary = sinon.spy(boundary)
 
   const MockedFD = pq("../../lib/FormData", {
     "./util/boundary": {

--- a/src/test/FormData/common.mjs
+++ b/src/test/FormData/common.mjs
@@ -1,5 +1,4 @@
-import {Readable} from "stream"
-import {join} from "path"
+import stream from "stream"
 
 import test from "ava"
 
@@ -21,7 +20,7 @@ test("The stream accessor should return Readable stream", t => {
 
   const fd = new FormData()
 
-  t.true(fd.stream instanceof Readable)
+  t.true(fd.stream instanceof stream.Readable)
 })
 
 test("Boundary accessor should return a correct value", t => {

--- a/src/test/FormData/forEach.mjs
+++ b/src/test/FormData/forEach.mjs
@@ -1,6 +1,6 @@
 import test from "ava"
 
-import {spy} from "sinon"
+import sinon from "sinon"
 
 import FormData from "../../lib/FormData"
 
@@ -9,7 +9,7 @@ test(
   t => {
     t.plan(1)
 
-    const fulfill = spy()
+    const fulfill = sinon.spy()
 
     const fd = new FormData()
 
@@ -22,7 +22,7 @@ test(
 test("Callback should be called with the nullish context by default", t => {
   t.plan(1)
 
-  const fulfill = spy()
+  const fulfill = sinon.spy()
 
   const fd = new FormData()
 
@@ -36,7 +36,7 @@ test("Callback should be called with the nullish context by default", t => {
 test("Callback should be called with the specified context", t => {
   t.plan(2)
 
-  const fulfill = spy()
+  const fulfill = sinon.spy()
 
   const ctx = new Map()
 
@@ -53,7 +53,7 @@ test("Callback should be called with the specified context", t => {
 test("Callback should be called with value, name and FormData itself", t => {
   t.plan(1)
 
-  const fulfill = spy()
+  const fulfill = sinon.spy()
 
   const fd = new FormData()
 
@@ -67,7 +67,7 @@ test("Callback should be called with value, name and FormData itself", t => {
 test("Callback should be called once on each filed", t => {
   t.plan(4)
 
-  const fulfill = spy()
+  const fulfill = sinon.spy()
 
   const fd = new FormData()
 

--- a/src/test/FormData/get.mjs
+++ b/src/test/FormData/get.mjs
@@ -1,15 +1,15 @@
 import {Readable} from "stream"
-import {join} from "path"
+import path from "path"
 
 import test from "ava"
 
-import {createReadStream, readFile} from "promise-fs"
+import promiseFS from "promise-fs"
 
 import FormData from "../../lib/FormData"
 
 import read from "../__helper__/read"
 
-const path = join(__dirname, "..", "..", "package.json")
+const filePath = path.join(__dirname, "..", "..", "package.json")
 
 test("Should return \"undefined\" on getting nonexistent field", t => {
   t.plan(1)
@@ -61,11 +61,11 @@ test("Should return a stringified values", t => {
 test("Should return Readable stream as-is", async t => {
   t.plan(2)
 
-  const expected = await readFile(path)
+  const expected = await promiseFS.readFile(filePath)
 
   const fd = new FormData()
 
-  fd.set("stream", createReadStream(path))
+  fd.set("stream", promiseFS.createReadStream(filePath))
 
   const actual = fd.get("stream")
 
@@ -76,7 +76,7 @@ test("Should return Readable stream as-is", async t => {
 test("Should return Buffer value as-is", async t => {
   t.plan(2)
 
-  const buffer = await readFile(path)
+  const buffer = await promiseFS.readFile(filePath)
 
   const fd = new FormData()
 

--- a/src/test/FormData/getAll.mjs
+++ b/src/test/FormData/getAll.mjs
@@ -1,5 +1,5 @@
-import {createReadStream, readFile} from "promise-fs"
-import {join} from "path"
+import promiseFS from "promise-fs"
+import path from "path"
 
 import test from "ava"
 
@@ -7,7 +7,7 @@ import FormData from "../../lib/FormData"
 
 const isArray = Array.isArray
 
-const path = join(__dirname, "..", "..", "package.json")
+const filePath = path.join(__dirname, "..", "..", "package.json")
 
 test(
   "Should always return an array, even if the FormData have no fileds",
@@ -35,7 +35,7 @@ test("Should return an array with non-stringified Readable", t => {
 
   const fd = new FormData()
 
-  const stream = createReadStream(path)
+  const stream = promiseFS.createReadStream(filePath)
 
   fd.set("stream", stream)
 
@@ -50,7 +50,7 @@ test("Should return an array with non-stringified Buffer", async t => {
 
   const fd = new FormData()
 
-  const buffer = await readFile(path)
+  const buffer = await promiseFS.readFile(filePath)
 
   fd.set("buffer", buffer)
 

--- a/src/test/FormData/set.mjs
+++ b/src/test/FormData/set.mjs
@@ -1,12 +1,12 @@
-import {createReadStream} from "fs"
-import {Readable} from "stream"
-import {join} from "path"
+import fs from "fs"
+import stream from "stream"
+import path from "path"
 
 import test from "ava"
 
 import FormData from "../../lib/FormData"
 
-const path = join(__dirname, "..", "..", "package.json")
+const filePath = path.join(__dirname, "..", "..", "package.json")
 
 test("Should set a primitive value", t => {
   t.plan(4)
@@ -82,9 +82,9 @@ test("Should set a Readable stream", t => {
 
   const fd = new FormData()
 
-  fd.set("stream", createReadStream(path))
+  fd.set("stream", fs.createReadStream(filePath))
 
-  t.true(fd.get("stream") instanceof Readable)
+  t.true(fd.get("stream") instanceof stream.Readable)
 })
 
 test("Should correctly add a field with Buffer data", t => {

--- a/src/test/__helper__/server.mjs
+++ b/src/test/__helper__/server.mjs
@@ -1,4 +1,4 @@
-import {createServer} from "http"
+import http from "http"
 
 import busboy, {isFile} from "then-busboy"
 import isPlainObject from "lodash.isplainobject"
@@ -21,7 +21,7 @@ async function mapFiles(obj, cb, ctx) {
   return res
 }
 
-const server = () => createServer((req, res) => {
+const server = () => http.createServer((req, res) => {
   const onData = data => mapFiles(
     data, async value => String(isFile(value) ? await value.read() : value)
   )

--- a/src/test/util/StreamIterator.mjs
+++ b/src/test/util/StreamIterator.mjs
@@ -3,7 +3,7 @@ import path from "path"
 
 import test from "ava"
 
-import {createReadStream, readFile} from "promise-fs"
+import promiseFS from "promise-fs"
 
 import read from "../__helper__/readStreamWithAsyncIterator"
 
@@ -14,7 +14,7 @@ const filePath = path.join(__dirname, "..", "..", "package.json")
 test("Should have a \"next\" method", t => {
   t.plan(1)
 
-  const iterator = new StreamIterator(createReadStream(filePath))
+  const iterator = new StreamIterator(promiseFS.createReadStream(filePath))
 
   t.is(typeof iterator.next, "function")
 })
@@ -73,7 +73,8 @@ test("Should return correctly object on readStream ending", async t => {
 })
 
 test("Should correctly read a content from the readStream", async t => {
-  const iterator = new StreamIterator(createReadStream("/usr/share/dict/words"))
+  const iterator
+    = new StreamIterator(promiseFS.createReadStream("/usr/share/dict/words"))
 
   const chunks = []
 
@@ -81,7 +82,7 @@ test("Should correctly read a content from the readStream", async t => {
     chunks.push(chunk)
   }
 
-  const expected = await readFile("/usr/share/dict/words")
+  const expected = await promiseFS.readFile("/usr/share/dict/words")
   const actual = Buffer.concat(chunks)
 
   t.true(actual.equals(expected))
@@ -90,7 +91,7 @@ test("Should correctly read a content from the readStream", async t => {
 test("Should throw an error from strem event", async t => {
   t.plan(1)
 
-  const readStream = createReadStream("/usr/share/dict/words")
+  const readStream = promiseFS.createReadStream("/usr/share/dict/words")
 
   const trap = () => {
     const iterator = new StreamIterator(readStream)

--- a/src/test/util/StreamIterator.mjs
+++ b/src/test/util/StreamIterator.mjs
@@ -1,5 +1,5 @@
-import {Readable} from "stream"
-import {join} from "path"
+import stream from "stream"
+import path from "path"
 
 import test from "ava"
 
@@ -9,12 +9,12 @@ import read from "../__helper__/readStreamWithAsyncIterator"
 
 import StreamIterator from "../../lib/util/StreamIterator"
 
-const path = join(__dirname, "..", "..", "package.json")
+const filePath = path.join(__dirname, "..", "..", "package.json")
 
 test("Should have a \"next\" method", t => {
   t.plan(1)
 
-  const iterator = new StreamIterator(createReadStream(path))
+  const iterator = new StreamIterator(createReadStream(filePath))
 
   t.is(typeof iterator.next, "function")
 })
@@ -22,11 +22,11 @@ test("Should have a \"next\" method", t => {
 test("The next method should return a Promise", async t => {
   t.plan(1)
 
-  const stream = new Readable({
+  const readStream = new stream.Readable({
     read() { this.push(null) }
   })
 
-  const iterator = new StreamIterator(stream)
+  const iterator = new StreamIterator(readStream)
 
   const actual = iterator.next()
 
@@ -38,31 +38,31 @@ test("The next method should return a Promise", async t => {
 test("Should return a value in correct format", async t => {
   t.plan(3)
 
-  const stream = new Readable({
+  const readStream = new stream.Readable({
     read() { /* noop */ }
   })
 
-  stream.push(Buffer.from("I've seen things you people wouldn't believe"))
+  readStream.push(Buffer.from("I've seen things you people wouldn't believe"))
 
-  const iterator = new StreamIterator(stream)
+  const iterator = new StreamIterator(readStream)
 
   const actual = await iterator.next()
 
-  stream.push(null)
+  readStream.push(null)
 
   t.deepEqual(Object.keys(actual).sort(), ["done", "value"])
   t.is(String(actual.value), "I've seen things you people wouldn't believe")
   t.false(actual.done)
 })
 
-test("Should return correctly object on stream ending", async t => {
+test("Should return correctly object on readStream ending", async t => {
   t.plan(1)
 
-  const stream = new Readable({
+  const readStream = new stream.Readable({
     read() { this.push(null) }
   })
 
-  const iterator = new StreamIterator(stream)
+  const iterator = new StreamIterator(readStream)
 
   const actual = await iterator.next()
 
@@ -72,7 +72,7 @@ test("Should return correctly object on stream ending", async t => {
   })
 })
 
-test("Should correctly read a content from the stream", async t => {
+test("Should correctly read a content from the readStream", async t => {
   const iterator = new StreamIterator(createReadStream("/usr/share/dict/words"))
 
   const chunks = []
@@ -90,12 +90,12 @@ test("Should correctly read a content from the stream", async t => {
 test("Should throw an error from strem event", async t => {
   t.plan(1)
 
-  const stream = createReadStream("/usr/share/dict/words")
+  const readStream = createReadStream("/usr/share/dict/words")
 
   const trap = () => {
-    const iterator = new StreamIterator(stream)
+    const iterator = new StreamIterator(readStream)
 
-    stream.emit("error", new Error("Just an error."))
+    readStream.emit("error", new Error("Just an error."))
 
     return read(iterator)
   }

--- a/src/test/util/getType.mjs
+++ b/src/test/util/getType.mjs
@@ -1,4 +1,4 @@
-import {isString} from "util"
+import util from "util"
 
 import test from "ava"
 
@@ -9,7 +9,7 @@ test("Should return a string with type name", t => {
 
   const res = getType({})
 
-  t.true(isString(res))
+  t.true(util.isString(res))
   t.is(res, "object")
 })
 


### PR DESCRIPTION
This PR adds support for native ESM for Node.js in [`--experimental-modules`](https://nodejs.org/api/esm.html#esm_enabling) mode by shipping sibling `.mjs` ESM files next to the existing `.js` CJS files, and by removing the file extension from the `package.json` `main` field.

This allows people use simultaneously use Babel and native ESM to consume this package without showstopping `default` interop errors (see https://github.com/babel/babel/issues/7294 and https://github.com/babel/babel/issues/7998).

While I was at it:

- Fixed faux ESM imports. As a rule for `.mjs` files, if the file being imported does not have the `.mjs` extension and contain ESM, do not import from it using ESM named imports.
- Replaced `yarn` for `npm run` where relevant. This is best practice; Yarn understands the npm scripts, but npm does not understand Yarn. Now both Yarn and npm can be used to run the package scripts.
- Simplified scripts to not have to use bin paths everywhere.
- Fixed a few minor `.mjs` related tool misconfigurations.

For reference, here is how I approach package scripts and native ESM support in my packages:

https://github.com/jaydenseric/extract-files/blob/v5.0.1/package.json#L60