### PR TITLE
Fix typo in __defaultContentType value

### DIFF
--- a/src/lib/FormData.mjs
+++ b/src/lib/FormData.mjs
@@ -40,7 +40,7 @@ class FormData {
     ], this)
 
     this.__carriage = "\r\n"
-    this.__defaultContentType = "application/octet-steam"
+    this.__defaultContentType = "application/octet-stream"
 
     this.__dashes = "--"
     this.__boundary = concat(["NodeJSFormDataStream", boundary()])


### PR DESCRIPTION
The value set for `__defaultContentType` is meant to be `application/octet-stream`.