### PR TITLE
Coerce field names to string

### DIFF
--- a/src/lib/FormData.mjs
+++ b/src/lib/FormData.mjs
@@ -260,6 +260,7 @@ class FormData {
    * @private
    */
   __setField(name, value, filename, options, append, argsLength) {
+    const fieldName = String(name)
     const methodName = append ? "append" : "set"
 
     if (isObject(filename)) {
@@ -311,18 +312,18 @@ class FormData {
       value = String(value)
     }
 
-    const field = this.__content.get(name)
+    const field = this.__content.get(fieldName)
 
     // Set a new field if given name is not exists
     if (!field) {
-      return void this.__content.set(String(name), {
+      return void this.__content.set(fieldName, {
         append, values: [{value, filename}]
       })
     }
 
     // Replace a value of the existing field if "set" called
     if (!append) {
-      return void this.__content.set(String(name), {
+      return void this.__content.set(fieldName, {
         append, values: [{value, filename}]
       })
     }
@@ -335,7 +336,7 @@ class FormData {
     // Append a new value to the existing field
     field.values.push({value, filename})
 
-    this.__content.set(String(name), field)
+    this.__content.set(fieldName, field)
   }
 
   /**

--- a/src/lib/FormData.mjs
+++ b/src/lib/FormData.mjs
@@ -315,14 +315,14 @@ class FormData {
 
     // Set a new field if given name is not exists
     if (!field) {
-      return void this.__content.set(`${name}`, {
+      return void this.__content.set(String(name), {
         append, values: [{value, filename}]
       })
     }
 
     // Replace a value of the existing field if "set" called
     if (!append) {
-      return void this.__content.set(`${name}`, {
+      return void this.__content.set(String(name), {
         append, values: [{value, filename}]
       })
     }
@@ -335,7 +335,7 @@ class FormData {
     // Append a new value to the existing field
     field.values.push({value, filename})
 
-    this.__content.set(`${name}`, field)
+    this.__content.set(String(name), field)
   }
 
   /**
@@ -451,7 +451,7 @@ class FormData {
    * @public
    */
   get(name) {
-    const field = this.__content.get(`${name}`)
+    const field = this.__content.get(String(name))
 
     if (!field) {
       return undefined
@@ -469,7 +469,7 @@ class FormData {
    * @public
    */
   getAll(name) {
-    const field = this.__content.get(`${name}`)
+    const field = this.__content.get(String(name))
 
     return field ? Array.from(field.values, ({value}) => value) : []
   }
@@ -482,7 +482,7 @@ class FormData {
    * @public
    */
   delete(name) {
-    this.__content.delete(`${name}`)
+    this.__content.delete(String(name))
   }
 
   /**

--- a/src/lib/FormData.mjs
+++ b/src/lib/FormData.mjs
@@ -315,14 +315,14 @@ class FormData {
 
     // Set a new field if given name is not exists
     if (!field) {
-      return void this.__content.set(name, {
+      return void this.__content.set(`${name}`, {
         append, values: [{value, filename}]
       })
     }
 
     // Replace a value of the existing field if "set" called
     if (!append) {
-      return void this.__content.set(name, {
+      return void this.__content.set(`${name}`, {
         append, values: [{value, filename}]
       })
     }
@@ -335,7 +335,7 @@ class FormData {
     // Append a new value to the existing field
     field.values.push({value, filename})
 
-    this.__content.set(name, field)
+    this.__content.set(`${name}`, field)
   }
 
   /**
@@ -451,7 +451,7 @@ class FormData {
    * @public
    */
   get(name) {
-    const field = this.__content.get(name)
+    const field = this.__content.get(`${name}`)
 
     if (!field) {
       return undefined
@@ -469,7 +469,7 @@ class FormData {
    * @public
    */
   getAll(name) {
-    const field = this.__content.get(name)
+    const field = this.__content.get(`${name}`)
 
     return field ? Array.from(field.values, ({value}) => value) : []
   }
@@ -482,7 +482,7 @@ class FormData {
    * @public
    */
   delete(name) {
-    this.__content.delete(name)
+    this.__content.delete(`${name}`)
   }
 
   /**

--- a/src/test/FormData/append.mjs
+++ b/src/test/FormData/append.mjs
@@ -2,14 +2,24 @@ import test from "ava"
 
 import FormData from "../../lib/FormData"
 
-test("Appends a new value", t => {
+test("Appends new values, coercing field names to strings", t => {
   const fd = new FormData()
 
-  fd.append("name", "value")
+  fd.append("a", "a")
+  fd.append(1, "b")
+  fd.append(false, "c")
+  fd.append(null, "d")
+  fd.append(undefined, "e")
 
   t.deepEqual(
-    fd.getAll("name"), ["value"],
-    "Value should be returned as an array"
+    Array.from(fd.entries()),
+    [
+      ["a", "a"],
+      ["1", "b"],
+      ["false", "c"],
+      ["null", "d"],
+      ["undefined", "e"],
+    ]
   )
 })
 

--- a/src/test/FormData/delete.mjs
+++ b/src/test/FormData/delete.mjs
@@ -2,14 +2,23 @@ import test from "ava"
 
 import FormData from "../../lib/FormData"
 
-test("Removes a field by its key", t => {
+test("Deletes fields by field name, coercing the field names to strings", t => {
   const fd = new FormData()
 
-  fd.set("name", "value")
+  fd.set("a", "a")
+  fd.delete("a")
 
-  t.true(fd.has("name"))
+  fd.set(1, "b")
+  fd.delete("1")
 
-  fd.delete("name")
+  fd.set(false, "c")
+  fd.delete("false")
 
-  t.false(fd.has("name"))
+  fd.set(null, "d")
+  fd.delete("null")
+
+  fd.set(undefined, "e")
+  fd.delete("undefined")
+
+  t.is(Array.from(fd.entries()).length, 0)
 })

--- a/src/test/FormData/get.mjs
+++ b/src/test/FormData/get.mjs
@@ -17,21 +17,32 @@ const {stat, readFile} = fs
 
 const filePath = join(__dirname, "..", "..", "package.json")
 
-test("Returns \"undefined\" on getting nonexistent field", t => {
+test("Gets \"undefined\" on getting nonexistent field", t => {
   const fd = new FormData()
 
   t.is(fd.get("nope"), undefined)
 })
 
-test("Returns a value of the existing field by given name", t => {
+test("Gets values, coercing field names to strings", t => {
   const fd = new FormData()
 
-  fd.set("name", "John Doe")
+  fd.set("a", "a")
+  t.is(fd.get("a"), "a")
 
-  t.is(fd.get("name"), "John Doe")
+  fd.set("1", "b")
+  t.is(fd.get(1), "b")
+
+  fd.set("false", "c")
+  t.is(fd.get(false), "c")
+
+  fd.set("null", "d")
+  t.is(fd.get(null), "d")
+
+  fd.set("undefined", "e")
+  t.is(fd.get(undefined), "e")
 })
 
-test("Returns only the first value of the field", t => {
+test("Gets only the first value of the field", t => {
   const fd = new FormData()
 
   fd.append("name", "John Doe")
@@ -40,7 +51,7 @@ test("Returns only the first value of the field", t => {
   t.is(fd.get("name"), "John Doe")
 })
 
-test("Returns a stringified values", t => {
+test("Gets a stringified values", t => {
   const fd = new FormData()
 
   fd.set("null", null)
@@ -56,7 +67,7 @@ test("Returns a stringified values", t => {
   t.is(fd.get("object"), "[object Object]")
 })
 
-test("Returns Buffer value as File", async t => {
+test("Gets Buffer value as File", async t => {
   const buffer = await readFile(filePath)
 
   const fd = new FormData()
@@ -68,7 +79,7 @@ test("Returns Buffer value as File", async t => {
   t.true(actual instanceof FileLike)
 })
 
-test("Returns Blob value as File", t => {
+test("Gets Blob value as File", t => {
   const blob = new Blob(["Some text"], {type: "text/plain"})
 
   const fd = new FormData()
@@ -80,7 +91,7 @@ test("Returns Blob value as File", t => {
   t.true(actual instanceof FileLike)
 })
 
-test("Returns File value as-is", t => {
+test("Gets File value as-is", t => {
   const file = new File(["Some text"], "file.txt", {type: "text/plain"})
 
   const fd = new FormData()
@@ -92,7 +103,7 @@ test("Returns File value as-is", t => {
   t.true(actual instanceof File)
 })
 
-test("Returns ReadStream stream as-is", async t => {
+test("Gets ReadStream stream as-is", async t => {
   const expected = await readFile(filePath)
 
   const fd = new FormData()
@@ -106,7 +117,7 @@ test("Returns ReadStream stream as-is", async t => {
 })
 
 test(
-  "Returns File when ReadStream passed with options.size argument",
+  "Gets File when ReadStream passed with options.size argument",
 
   async t => {
     const fd = new FormData()
@@ -121,7 +132,7 @@ test(
   }
 )
 
-test("Returns Readable stream as-is", t => {
+test("Gets Readable stream as-is", t => {
   const fd = new FormData()
 
   const readable = new Readable({
@@ -136,7 +147,7 @@ test("Returns Readable stream as-is", t => {
 })
 
 test(
-  "Returns File when Readable stream passed with options.size argument",
+  "Gets File when Readable stream passed with options.size argument",
 
   t => {
     const fd = new FormData()
@@ -153,7 +164,7 @@ test(
   }
 )
 
-test("Returns File when ReadableStream as-is", t => {
+test("Gets File when ReadableStream as-is", t => {
   const readable = new ReadableStream({
     start(controller) {
       controller.close()
@@ -168,7 +179,7 @@ test("Returns File when ReadableStream as-is", t => {
 })
 
 test(
-  "Returns File when ReadableStream passed with options.size argument",
+  "Gets File when ReadableStream passed with options.size argument",
 
   t => {
     const readable = new ReadableStream({

--- a/src/test/FormData/getAll.mjs
+++ b/src/test/FormData/getAll.mjs
@@ -13,10 +13,29 @@ const {isArray} = Array
 
 const filePath = join(__dirname, "..", "..", "package.json")
 
-test("Always returns an array, even if the FormData have no fileds", t => {
+test("Always returns an array, even if the FormData has no fields", t => {
   const fd = new FormData()
 
   t.true(isArray(fd.getAll("nope")))
+})
+
+test("Gets all values, coercing names to strings", t => {
+  const fd = new FormData()
+
+  fd.set("a", "a")
+  t.deepEqual(fd.getAll("a"), ["a"])
+
+  fd.set("1", "b")
+  t.deepEqual(fd.getAll(1), ["b"])
+
+  fd.set("false", "c")
+  t.deepEqual(fd.getAll(false), ["c"])
+
+  fd.set("null", "d")
+  t.deepEqual(fd.getAll(null), ["d"])
+
+  fd.set("undefined", "e")
+  t.deepEqual(fd.getAll(undefined), ["e"])
 })
 
 test("Returns an array with the stringified primitive value", t => {
@@ -27,7 +46,7 @@ test("Returns an array with the stringified primitive value", t => {
   t.deepEqual(fd.getAll("number"), ["451"])
 })
 
-test("Return an array with non-stringified Readable", t => {
+test("Returns an array with non-stringified Readable", t => {
   const fd = new FormData()
 
   const stream = createReadStream(filePath)
@@ -40,7 +59,7 @@ test("Return an array with non-stringified Readable", t => {
   )
 })
 
-test("Return an array with non-stringified Buffer", async t => {
+test("Returns an array with non-stringified Buffer", async t => {
   const fd = new FormData()
 
   const buffer = await readFile(filePath)

--- a/src/test/FormData/set.mjs
+++ b/src/test/FormData/set.mjs
@@ -14,6 +14,27 @@ import read from "../__helper__/read"
 
 const filePath = join(__dirname, "..", "..", "package.json")
 
+test("Sets new values, coercing field names to strings", t => {
+  const fd = new FormData()
+
+  fd.set("a", "a")
+  fd.set(1, "b")
+  fd.set(false, "c")
+  fd.set(null, "d")
+  fd.set(undefined, "e")
+
+  t.deepEqual(
+    Array.from(fd.entries()),
+    [
+      ["a", "a"],
+      ["1", "b"],
+      ["false", "c"],
+      ["null", "d"],
+      ["undefined", "e"],
+    ]
+  )
+})
+
 test("Should set a primitive value", t => {
   const fd = new FormData()
 


### PR DESCRIPTION
Fixes https://github.com/octet-stream/form-data/issues/22 .

Field name arguments of `get`, `getAll`, `set`, `append`, and `delete` are now coerced to string, like how native `FormData` implementations behave.

Also, while I was in the area I tidied some typos, etc. in the test names.