### PR TITLE
Fix precedence - user defined name for stream has higher precedence

### DIFF
--- a/lib/FormData.js
+++ b/lib/FormData.js
@@ -299,11 +299,11 @@ class FormData {
           || filename
           || (value.constructor.name === "Blob" ? "blob" : String(value.name))
       )
-    } else if (isStream(value) && (value.path || filename)) {
+    } else if (isStream(value) && (filename || value.path)) {
       // Readable stream which created from fs.createReadStream
       // have a "path" property. So, we can get a "filename"
       // from the stream itself.
-      filename = basename(value.path || filename)
+      filename = basename(filename || value.path)
     }
 
     // Normalize field content


### PR DESCRIPTION
Bug: got a file in stream from mutler which saves the file in tmp directory. ReadableStream has path property that has a filename that I don't want to see in the request because I specify third parameter to formData.append function. 