### PR TITLE
Add "package.json" to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "module": "./lib/esm/browser.js",
   "browser": "./lib/cjs/browser.js",
   "exports": {
+    "./package.json": "./package.json",
     ".": {
       "node": {
         "import": "./lib/esm/index.js",


### PR DESCRIPTION
As per [Node.JS docs](https://nodejs.org/api/packages.html#packages_exports) this PR exposes `package.json` into the `exports` field to keep compatibility.