### PR TITLE
Fix package exports for TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,16 +21,19 @@
     "./package.json": "./package.json",
     ".": {
       "node": {
+        "types": "./@type/index.d.ts",
         "import": "./lib/esm/index.js",
         "require": "./lib/cjs/index.js"
       },
       "browser": {
+        "types": "./@type/browser.d.ts",
         "import": "./lib/esm/browser.js",
         "require": "./lib/cjs/browser.js"
       },
       "default": "./lib/esm/index.js"
     },
     "./file-from-path": {
+      "types": "./@type/fileFromPath.d.ts",
       "import": "./lib/esm/fileFromPath.js",
       "require": "./lib/cjs/fileFromPath.js"
     }


### PR DESCRIPTION
This PR fixes the package `exports` field for compatibility with prerelease `typescript` v4.6. Weirdly, `tsc` in the CLI didn't have problems resolving the type definition for imports but the VS Code TypeScript extension did.

Project code before, with `typescript` v4.6.0-dev.20211227:

<img width="830" alt="Screen Shot 2021-12-28 at 11 05 07 am" src="https://user-images.githubusercontent.com/1754873/147514777-b68d3ea4-3639-4db3-be43-f0956687a5f1.png">

After the changes in this PR:

<img width="737" alt="Screen Shot 2021-12-28 at 11 06 28 am" src="https://user-images.githubusercontent.com/1754873/147514785-022714c2-7565-46e6-bfce-cca4b06ff9ab.png">

The specific change needed for the fix in the package `exports` field was the addition of `exports["."].node.types`. The others are added because it might solve other problems. I don't fully understand what the point of the `typesVersions` field is, so you might want to consider it.

See [this TypeScript guide](https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing).

For the record, this PR works with the patterns already established but I would setup the files and package exports differently.