### PR TITLE
Upgrade web-streams-polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,6 @@
   },
   "dependencies": {
     "node-domexception": "1.0.0",
-    "web-streams-polyfill": "4.0.0-beta.2"
+    "web-streams-polyfill": "4.0.0-beta.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,11 +21,11 @@ specifiers:
   sinon: 14.0.0
   ts-node: 10.9.1
   typescript: 4.7.4
-  web-streams-polyfill: 4.0.0-beta.2
+  web-streams-polyfill: 4.0.0-beta.3
 
 dependencies:
   node-domexception: 1.0.0
-  web-streams-polyfill: 4.0.0-beta.2
+  web-streams-polyfill: 4.0.0-beta.3
 
 devDependencies:
   '@octetstream/eslint-config': 6.2.2_d65vm3i52yjzbdjlrwl4bvhoem
@@ -3284,8 +3284,8 @@ packages:
       spdx-expression-parse: 3.0.1
     dev: true
 
-  /web-streams-polyfill/4.0.0-beta.2:
-    resolution: {integrity: sha512-UHhhnoe2M40uh2r0KVdJTN7qjFytm6o0Yp3VcjwV3bfo6rz8uqvxNoE5yNmGF0y3eFfXaFeb6M09MDSwwLmq4w==}
+  /web-streams-polyfill/4.0.0-beta.3:
+    resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
     engines: {node: '>= 14'}
     dev: false
 


### PR DESCRIPTION
The beta3 is resolving a bug that isn't affecting form-data directly, but it could be affect projects that rely on form-data dependency version:

https://github.com/MattiasBuelens/web-streams-polyfill/releases/tag/v4.0.0-beta.3