### PR TITLE
chore: update package.json for bundler module resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,13 +24,19 @@
   "browser": "./lib/browser.js",
   "exports": {
     "./package.json": "./package.json",
-    ".": {
-      "types": "./@type/index.d.ts",
-      "import": "./lib/index.js"
-    },
-    "./browser": {
-      "types": "./@type/browser.d.ts",
-      "import": "./lib/browser.js"      
+    "./": {
+      "node": {
+        "types": "./@type/index.d.ts",
+        "import": "./lib/index.js"
+      },
+      "browser": {
+        "types": "./@type/browser.d.ts",
+        "import": "./lib/browser.js"
+      },
+      "default": {
+        "types": "./@type/index.d.ts",
+        "import": "./lib/index.js"
+      }
     },
     "./file-from-path": {
       "types": "./@type/fileFromPath.d.ts",
@@ -40,9 +46,6 @@
   "types": "./@type/index.d.ts",
   "typesVersions": {
     "*": {
-      "browser": [
-        "@type/browser.d.ts"
-      ],
       "file-from-path": [
         "@type/fileFromPath.d.ts"
       ]

--- a/package.json
+++ b/package.json
@@ -25,15 +25,12 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "node": {
-        "types": "./@type/index.d.ts",
-        "import": "./lib/index.js"
-      },
-      "browser": {
-        "types": "./@type/browser.d.ts",
-        "import": "./lib/browser.js"
-      },
-      "default": "./lib/index.js"
+      "types": "./@type/index.d.ts",
+      "import": "./lib/index.js"
+    },
+    "./browser": {
+      "types": "./@type/browser.d.ts",
+      "import": "./lib/browser.js"      
     },
     "./file-from-path": {
       "types": "./@type/fileFromPath.d.ts",
@@ -43,6 +40,9 @@
   "types": "./@type/index.d.ts",
   "typesVersions": {
     "*": {
+      "browser": [
+        "@type/browser.d.ts"
+      ],
       "file-from-path": [
         "@type/fileFromPath.d.ts"
       ]

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "browser": "./lib/browser.js",
   "exports": {
     "./package.json": "./package.json",
-    "./": {
+    ".": {
       "node": {
         "types": "./@type/index.d.ts",
         "import": "./lib/index.js"


### PR DESCRIPTION
When setting moduleResolution: bundler, in TS5, the current exports will not work. Error:

> There are types at '/node_modules/formdata-node/@type/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'formdata-node' library may need to update its package.json or typings.ts(7016)

